### PR TITLE
FIX No longer train batch-norm layer during pretraining

### DIFF
--- a/sccoral/model/_model.py
+++ b/sccoral/model/_model.py
@@ -403,7 +403,7 @@ class SCCORAL(BaseModelClass, TunableMixin, VAEMixin):
                 n_pretraining_epochs=pretraining_max_epochs,
                 early_stopping=pretraining_early_stopping,
                 lr=lr,
-                train_batch_norm=True,
+                train_batch_norm=False,
             )
 
             if "callbacks" not in trainer_kwargs:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -55,7 +55,7 @@ def test_pretraining_max_epochs(adata, max_pretraining_epochs, requires_grad):
         pretraining_max_epochs=max_pretraining_epochs,
         pretraining_early_stopping=False,
     )
-    assert model.module.z_encoder.encoder.fc_layers[0][0].weight.requires_grad == requires_grad
+    assert all([param.requires_grad == requires_grad for name, param in model.module.z_encoder.named_parameters()])
 
 
 @pytest.mark.parametrize(["pretraining_early_stopping", "requires_grad"], [[True, True], [False, False]])
@@ -75,7 +75,7 @@ def test_pretraining_early_stopping(adata, pretraining_early_stopping, requires_
         pretraining_min_delta=np.inf,
         pretraining_early_stopping_patience=1,
     )
-    assert model.module.z_encoder.encoder.fc_layers[0][0].weight.requires_grad == requires_grad
+    assert all([param.requires_grad == requires_grad for name, param in model.module.z_encoder.named_parameters()])
 
 
 @pytest.fixture(scope="module", params=["normal", "ln"])


### PR DESCRIPTION
Fix the issue that the gradient of the batch norm layer was still incorrectly updated during pretraining. On some rare occasions (i.e. some random initializations), this led to the issue that the covariate-informed dimension did not capture the covariate-associated gene expression anymore. 

Updated
- Freeze batch norm layer during pretraining
- Updated unit tests. Unit tests now capture this unwanted behavior