### PR TITLE
UPDATE - `get_latent_representation`

### DIFF
--- a/sccoral/data/datasets.py
+++ b/sccoral/data/datasets.py
@@ -56,7 +56,7 @@ def splatter_simulation(save_path: str = "data/", filename: str = "simulation.h5
     .. [1] Zappia, L., Phipson, B. & Oshlack, A. Splatter: simulation of single-cell RNA sequencing data. Genome Biol 18, 174 (2017).
     .. [2] Gerard, D. Data-based RNA-seq simulations by binomial thinning. BMC Bioinformatics 21, 206 (2020).
     """
-    url = "https://figshare.com/ndownloader/files/44184947?private_link=199140ec1dc329efcfbd"
+    url = "https://www.dropbox.com/scl/fi/tf6qks693176jk61e2gdd/simulation.1.simplified.h5ad?rlkey=xe0b03y2baeg92h8bdjfi76f5&st=9ihmva4s&dl=1"
 
     if not os.path.exists(save_path):
         os.mkdir(save_path)

--- a/sccoral/model/_model.py
+++ b/sccoral/model/_model.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from typing import Any, Literal
 
 import anndata as ad
+import numpy as np
 import pandas as pd
 import torch
 from scvi import REGISTRY_KEYS
@@ -204,11 +205,15 @@ class SCCORAL(BaseModelClass, TunableMixin, VAEMixin):
     @inference_mode()
     def get_latent_representation(
         self,
-        adata: None | ad.AnnData = None,
+        adata: ad.AnnData | None = None,
+        indices: Iterable[int] | None = None,
+        give_mean: bool = True,
+        mc_samples: int = 5000,
+        batch_size: int | None = None,
+        return_dist: bool = False,
         set_column_names: bool = True,
-        indices: Iterable = None,
-        batch_size: int = None,
-    ) -> pd.DataFrame:
+        suffix: str | None = None,
+    ) -> pd.DataFrame | tuple[np.ndarray, np.ndarray]:
         """Get latent representation of cells in anndata object
 
         Parameters
@@ -227,39 +232,30 @@ class SCCORAL(BaseModelClass, TunableMixin, VAEMixin):
         Pandas DataFrame
             `n_cells` x `n_latent`
         """
-        if not self.is_trained_:
-            raise RuntimeError("Train model first")
+        res = super().get_latent_representation(adata, indices, give_mean, mc_samples, batch_size, return_dist)
 
         if adata is None:
             adata = self.adata
-        adata = self._validate_anndata(adata)
 
-        # Instantiate data loader
-        scdl = self._make_data_loader(adata=adata, indices=indices, batch_size=batch_size)
-        latent = []
+        if return_dist:
+            return res
 
-        # Inference
-        for tensors in scdl:
-            inference_inputs = self.module._get_inference_input(tensors)
-            outputs = self.module.inference(**inference_inputs)
+        else:
+            column_names = None
+            if set_column_names:
+                categorical_names = self.module.categorical_names if self.module.categorical_names is not None else []
+                continuous_names = self.module.continuous_names if self.module.continuous_names is not None else []
 
-            z = outputs["z"]
+                column_names = [
+                    # Free factors
+                    *list(range(self.module.n_latent)),
+                    *categorical_names,
+                    *continuous_names,
+                ]
+            if suffix is not None:
+                column_names = [f"{col}{suffix}" for col in column_names]
 
-            latent.append(z.cpu())
-
-        column_names = None
-        if set_column_names:
-            categorical_names = self.module.categorical_names if self.module.categorical_names is not None else []
-            continuous_names = self.module.continuous_names if self.module.continuous_names is not None else []
-
-            column_names = [
-                # Free factors
-                *list(range(self.module.n_latent)),
-                *categorical_names,
-                *continuous_names,
-            ]
-
-        return pd.DataFrame(torch.cat(latent).detach().numpy(), index=adata.obs_names, columns=column_names)
+            return pd.DataFrame(res, index=adata.obs_names, columns=column_names)
 
     @inference_mode()
     def get_explained_variance_per_factor(

--- a/sccoral/model/_model.py
+++ b/sccoral/model/_model.py
@@ -220,12 +220,23 @@ class SCCORAL(BaseModelClass, TunableMixin, VAEMixin):
         ----------
         adata
             AnnData object to embed. If `None` use stored `anndata.AnnData`
-        set_column_names
-            Whether to set the column names to covariate names
         indices
-            Indices of cells to retrieve
+            Indices of cells to retrieve (see scvi-tools)
+        give_mean
+            Whether to give the full distribution or mean of distribution. Defaults to mean
+            See scvi-tools
+        mc_samples
+            For distributions with no closed analytical solution - how many samples to draw (see scvi-tools)
         batch_size
             Batch size during inference.
+        return_dist
+            Whether to return single-measurement values (False) or parameters of the distribution (True)
+            See scvi-tools
+        set_column_names
+            Whether to set the column names to covariate names (defaults to True)
+        suffix
+            Whether to add a suffix (e.g. `__factor`) so that columns in dataframe are better distinguishable 
+            from metadata info. Per default, no suffix is added.
 
         Returns
         -------

--- a/sccoral/nn/_components.py
+++ b/sccoral/nn/_components.py
@@ -11,6 +11,11 @@ def _no_grad_absolute(tensor: Tensor) -> Tensor:
     """Return absolute value of tensor"""
     with torch.no_grad():
         return torch.absolute(tensor)
+    
+def _no_grad_zero(tensor: Tensor) -> Tensor:
+    """Return absolute value of tensor"""
+    with torch.no_grad():
+        return torch.zeros_like(tensor)
 
 
 class LinearEncoder(nn.Module):
@@ -51,6 +56,7 @@ class LinearEncoder(nn.Module):
         # as the class with "high" factor activity.
         if init_positive:
             self.mean.weight.data = _no_grad_absolute(self.mean.weight.data)
+            self.mean.bias.data = _no_grad_zero(self.mean.bias.data)
 
         self.var = nn.Linear(n_input, n_output, bias=var_bias)
 

--- a/sccoral/nn/_components.py
+++ b/sccoral/nn/_components.py
@@ -3,8 +3,14 @@ from typing import Literal, Optional
 
 import torch
 from scvi.nn import FCLayers
-from torch import nn
+from torch import Tensor, nn
 from torch.distributions import Normal
+
+
+def _no_grad_absolute(tensor: Tensor) -> Tensor:
+    """Return absolute value of tensor"""
+    with torch.no_grad():
+        return torch.absolute(tensor)
 
 
 class LinearEncoder(nn.Module):
@@ -35,10 +41,17 @@ class LinearEncoder(nn.Module):
         mean_bias: bool = True,
         var_bias: bool = True,
         var_eps: float = 1e-4,
+        init_positive: bool = True,
     ):
         super().__init__()
 
         self.mean = nn.Linear(n_input, n_output, bias=mean_bias)
+
+        # Implement expected behaviour for positive class to be initialized
+        # as the class with "high" factor activity.
+        if init_positive:
+            self.mean.weight.data = _no_grad_absolute(self.mean.weight.data)
+
         self.var = nn.Linear(n_input, n_output, bias=var_bias)
 
         self.var_eps = var_eps

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -104,6 +104,11 @@ def test_representation(basic_train):
     assert "continuous_covariate" in representation.columns
 
 
+def test_representation_suffix(basic_train):
+    representation = basic_train.get_latent_representation(suffix='__factor')
+    assert "categorical_covariate__factor" in representation.columns
+    assert "continuous_covariate__factor" in representation.columns
+
 def test_get_reconstruction_error(basic_train):
     # Setup new anndata
     adata = synthetic_iid(batch_size=50, n_genes=100, n_proteins=0, n_regions=0, n_batches=1, n_labels=2)


### PR DESCRIPTION
**Get means of latent distribution**
Instead of sampling from the posterior, we use the implementation of scvi-tools and return the actual parameters of the latent distribution

**Enhancement related to Issue #11** 
Optionally, one can add a suffix (e.g. `__factor`) to the columns of the dataframe that is returned by `get_latent_representation`

**Updated link to simulated data** 
Updated link to obtain example datasets to dropbox location instead of figshare (the figshare link seems to be unstable and occasionally returns a HTTP403 error). 

**Positive initialization** 
Initialize weights for covariate dimensions with uniformly sampled **positive** values to mitigate unexpected behavior that embeddings are randomly reversed. 